### PR TITLE
New option "owned" in sub paste()

### DIFF
--- a/lib/WWW/Pastebin/PastebinCom/API.pm
+++ b/lib/WWW/Pastebin/PastebinCom/API.pm
@@ -394,7 +394,7 @@ sub _prepare_optional_api_options {
         push @out_args, api_paste_format => $args->{format};
     }
 
-    if( $args->{owned} ) {
+    if( $args->{owned} && !$args->{private} ) {
         defined ( $args->{user_key} || $self->user_key )
             or return $self->set_error(
                 'API user key must be provided to create owned pastes.'

--- a/lib/WWW/Pastebin/PastebinCom/API.pm
+++ b/lib/WWW/Pastebin/PastebinCom/API.pm
@@ -394,6 +394,18 @@ sub _prepare_optional_api_options {
         push @out_args, api_paste_format => $args->{format};
     }
 
+	if( $args->{owned} ) {
+		defined ( $args->{user_key} || $self->user_key )
+			or return $self->set_error(
+                'API user key must be provided to create owned pastes.'
+                    . ' See ->user_key() or ->get_user_key() in the'
+                    . ' documentation.'
+			);
+
+			push @out_args,
+				api_user_key => ( $args->{user_key} || $self->user_key );
+	}
+
     if ( $args->{private} ) {
         defined ( $args->{user_key} || $self->user_key )
             or return $self->_set_error(

--- a/lib/WWW/Pastebin/PastebinCom/API.pm
+++ b/lib/WWW/Pastebin/PastebinCom/API.pm
@@ -394,17 +394,17 @@ sub _prepare_optional_api_options {
         push @out_args, api_paste_format => $args->{format};
     }
 
-	if( $args->{owned} ) {
-		defined ( $args->{user_key} || $self->user_key )
-			or return $self->set_error(
+    if( $args->{owned} ) {
+        defined ( $args->{user_key} || $self->user_key )
+            or return $self->set_error(
                 'API user key must be provided to create owned pastes.'
                     . ' See ->user_key() or ->get_user_key() in the'
                     . ' documentation.'
-			);
+            );
 
-			push @out_args,
-				api_user_key => ( $args->{user_key} || $self->user_key );
-	}
+            push @out_args,
+                api_user_key => ( $args->{user_key} || $self->user_key );
+    }
 
     if ( $args->{private} ) {
         defined ( $args->{user_key} || $self->user_key )


### PR DESCRIPTION
Hi,
I found your module very pleasant to use and added a new feature.
If you like it feel free to merge, if not, change it as you like or ignore it :-)
If there are some files (tests?) where my change would need additional changes, let me know.

This PR adds the option `owned` to the `paste()` sub, or better in `_prepare_optional_api_options()`.

When given, the `user_key` is send in the API request in the field `api_user_key`, making the paste owned by the user. Therefore, the `user_key` has to be supplied by the user and/or username/password combination must result in a positive `$api->get_user_key()` request.

**NB:** By default, at least for normal pastebin users, the resulting paste will be unlisted, even if `api_paste_private = 0`!
`api_paste_private = 2` (ie `'private' => 1` in `paste()` will still result in a private paste, though.
I did not find a way to make a listed/public paste owned by a logged in user, unfortunately. Maybe this is possible for PRO users, only?!
